### PR TITLE
Add image to popular projects, Notification Handling implemented

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -273,9 +273,9 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -2357,9 +2357,9 @@
       }
     },
     "kareem": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.2.1.tgz",
-      "integrity": "sha512-xpDFy8OxkFM+vK6pXy6JmH92ibeEFUuDWzas5M9L7MzVmHW3jzwAHxodCPV/BYkf4A31bVDLyonrMfp9RXb/oA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.0.tgz",
+      "integrity": "sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg=="
     },
     "keygrip": {
       "version": "1.0.2",
@@ -2399,19 +2399,14 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -2660,39 +2655,58 @@
       }
     },
     "mongoose": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.1.7.tgz",
-      "integrity": "sha512-9zus8yEovPqLo3S2iXz2Dg9YJAo8xG7m161abqJbUNIqZYjvpPwjmWAs6ChZnxEUpTYFOve//ljvyA5V5D9sNw==",
+      "version": "5.4.17",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.17.tgz",
+      "integrity": "sha512-9aAg8M0YUmGHQRDYvsKJ02wx/Qaof1Jn2iDH21ZtWGAZpQt9uVLNEOdcBuzi+lPJwGbLYh2dphdKX0sZ+dXAJQ==",
       "requires": {
         "async": "2.6.1",
-        "bson": "~1.0.5",
-        "kareem": "2.2.1",
-        "lodash.get": "4.4.2",
-        "mongodb": "3.0.10",
+        "bson": "~1.1.0",
+        "kareem": "2.3.0",
+        "mongodb": "3.1.13",
+        "mongodb-core": "3.1.11",
         "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.4.1",
-        "mquery": "3.0.0",
-        "ms": "2.0.0",
+        "mpath": "0.5.1",
+        "mquery": "3.2.0",
+        "ms": "2.1.1",
         "regexp-clone": "0.0.1",
+        "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
       },
       "dependencies": {
+        "bson": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
+          "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
+        },
         "mongodb": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.10.tgz",
-          "integrity": "sha512-jy9s4FgcM4rl8sHNETYHGeWcuRh9AlwQCUuMiTj041t/HD02HwyFgmm2VZdd9/mA9YNHaUJLqj0tzBx2QFivtg==",
+          "version": "3.1.13",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+          "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
           "requires": {
-            "mongodb-core": "3.0.9"
+            "mongodb-core": "3.1.11",
+            "safe-buffer": "^5.1.2"
           }
         },
         "mongodb-core": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.9.tgz",
-          "integrity": "sha512-buOWjdLLBlEqjHDeHYSXqXx173wHMVp7bafhdHxSjxWdB9V6Ri4myTqxjYZwL/eGFZxvd8oRQSuhwuIDbaaB+g==",
+          "version": "3.1.11",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
+          "integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
           "requires": {
-            "bson": "~1.0.4",
-            "require_optional": "^1.0.1"
+            "bson": "^1.1.0",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -2702,25 +2716,34 @@
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "mpath": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.4.1.tgz",
-      "integrity": "sha512-NNY/MpBkALb9jJmjpBlIi6GRoLveLUM0pJzgbp9vY9F7IQEb/HREC/nxrixechcQwd1NevOhJnWWV8QQQRE+OA=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+      "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
     },
     "mquery": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.0.0.tgz",
-      "integrity": "sha512-WL1Lk8v4l8VFSSwN3yCzY9TXw+fKVYKn6f+w86TRzOLSE8k1yTgGaLBPUByJQi8VcLbOdnUneFV/y3Kv874pnQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.0.tgz",
+      "integrity": "sha512-qPJcdK/yqcbQiKoemAt62Y0BAc0fTEKo1IThodBD+O5meQRJT/2HSe5QpBNwaa4CjskoGrYWsEyjkqgiE0qjhg==",
       "requires": {
-        "bluebird": "3.5.0",
-        "debug": "2.6.9",
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
         "regexp-clone": "0.0.1",
-        "sliced": "0.0.5"
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
       },
       "dependencies": {
-        "sliced": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
-          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.16.3",
     "mongo": "^0.1.0",
     "mongodb": "^3.1.0",
-    "mongoose": "^5.4.17",
+    "mongoose": "^5.4.7",
     "node": "^10.5.0",
     "node-memwatch": "^1.0.1",
     "nodemon": "^1.18.8",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.16.3",
     "mongo": "^0.1.0",
     "mongodb": "^3.1.0",
-    "mongoose": "^5.1.7",
+    "mongoose": "^5.4.17",
     "node": "^10.5.0",
     "node-memwatch": "^1.0.1",
     "nodemon": "^1.18.8",

--- a/views/css/other-landing.css
+++ b/views/css/other-landing.css
@@ -36,6 +36,15 @@ form input.form-control{
   position: fixed;
   width: 255px;
 }
+.project-img{
+  width: 15px;
+  height: 15px;
+  display: inline-block;
+  margin-right: 5px;
+
+  background-image: url('/img/eventcd (2).jpg');
+  border-radius: 12px;
+}
 .active-cyan-4 .fa {
     background-color: #2196f3;
     border-radius: 2px;

--- a/views/js/events.js
+++ b/views/js/events.js
@@ -1,0 +1,25 @@
+var events = {
+  events: {},
+
+  subscribe: function(eventName, fn) {
+    this.events[eventName] = this.events[eventName] || [];
+    this.events[eventName].push(fn);
+  },
+
+  unsubscribe: function(eventName, fn) {
+    if(this.events[eventName]) {
+      let idx = this.events[eventName].indexOf(fn);
+      this.events[eventName].splice(idx, 1);
+    }
+  },
+
+  publish: function(eventName, data) {
+    if(this.events[eventName]) {
+      this.events[eventName].forEach(function(fn) {
+        fn(data);
+      });
+    }
+  }
+}
+
+module.exports.events = events;

--- a/views/js/main-landing.js
+++ b/views/js/main-landing.js
@@ -1,0 +1,11 @@
+import { events } from './events.js';
+
+$(document).ready(function() {
+  const onNotify = function(data) {
+    console.log('Notification received:');
+    console.log(data);
+  }
+
+  events.subscribe('notification', onNotify);
+});
+

--- a/views/js/notify.js
+++ b/views/js/notify.js
@@ -1,0 +1,9 @@
+import { events } from './events.js';
+
+$(document).ready(function() {
+  var socket = io();
+
+  socket.on('notification', function(data) {
+    events.publish('notification', data);
+  });
+});

--- a/views/main-landing.ejs
+++ b/views/main-landing.ejs
@@ -15,6 +15,9 @@
         <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.5.4/css/mdb.min.css" rel="stylesheet">
         <!-- Your custom styles (optional) -->
         <link href="css/main-landing.css" rel="stylesheet">
+
+        <script src="/socket.io/socket.io.js"></script>
+
     </head>
     <body>
         <!-- Start your project here-->

--- a/views/other-landing.ejs
+++ b/views/other-landing.ejs
@@ -14,7 +14,7 @@
         <!-- Material Design Bootstrap -->
         <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.5.4/css/mdb.min.css" rel="stylesheet">
         <!-- Your custom styles (optional) -->
-        <link href="css/other-landing.css" rel="stylesheet">
+        <link href="/css/other-landing.css" rel="stylesheet">
 
         <style>
         .ch{
@@ -195,11 +195,11 @@
                     <!--Title-->
                     <a href="#" class="btn btn-danger btn-rounded">Proposed Project</a>
                     <!--Text-->
-                    <p class="card-text pr-text"><a class="blue-text font-weight-bold">Codeuino</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
-                    <p class="card-text pr-text"><a class="blue-text font-weight-bold">Certifier</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
-                    <p class="card-text pr-text"><a class="blue-text font-weight-bold">Chat Platform</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
-                    <p class="card-text pr-text"><a class="blue-text font-weight-bold">Badge Former</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
-                    <p class="card-text pr-text"><a class="blue-text font-weight-bold">Bots-VI</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
+                    <p class="card-text pr-text"><div class="project-img"></div><a class="blue-text font-weight-bold">Codeuino</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
+                    <p class="card-text pr-text"><div class="project-img"></div><a class="blue-text font-weight-bold">Certifier</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
+                    <p class="card-text pr-text"><div class="project-img"></div><a class="blue-text font-weight-bold">Chat Platform</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
+                    <p class="card-text pr-text"><div class="project-img"></div><a class="blue-text font-weight-bold">Badge Former</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
+                    <p class="card-text pr-text"><div class="project-img"></div><a class="blue-text font-weight-bold">Bots-VI</a> &emsp; This Project is about fjjfoj ffjfnfnf gngrgnf gogojgjg gjodjgjg</p>
                   </div>
 
                 </div>


### PR DESCRIPTION
# Problem
- A mechanism to handle all bundled notifications was needed as described in issue [13](https://github.com/codeuino/Social-Platform-Donut/issues/13)
- Images had to be added before names of popular names of projects as stated in issue [91](https://github.com/codeuino/Social-Platform-Donut/issues/91)

# Solution
- Solution to # 13 : Publisher/Subscriber model makes it easy for various GUI components to interact with updates in notifications. This is implemented in `views/js/events.js`. Now, in the file `views/js/notify.js` , we subscribe to the notifications. No GUI is implemented yet. Notifications will be displayed in console.
- Solution to # 91: Regarding images before popular project names, a separated `div` with css attribute `display-inline` was added. Size of image can be changed using css class `project-img`.

# Before and After Screenshots
## Before
![Before preview](https://i.ibb.co/Jj3Gbnx/Screenshot-from-2019-03-06-19-32-47.png)
## After
![After preview](https://i.ibb.co/0G8WcF1/Screenshot-from-2019-03-06-19-32-20.png)

### **Type of Change**
- [ ] Bug fix
- [ ] New Feature
- [x] Development of UI/UX prototypes
- [ ] Small refactor
- [ ] Change in Documentation

### **Checklist**
- [x] My code follow the same style as the codebase
- [ ] My Code changed required change in documentation
- [ ] I have updated the Readme accordingly
- [x] I made PR within **development branch only**