### PR TITLE
fix link for community guideline

### DIFF
--- a/views/all.ejs
+++ b/views/all.ejs
@@ -92,7 +92,7 @@
                   </div>
                 </div>
                 <div class="modal-footer">
-                  Are you a Organisation? <a href="signup_community.html">Click Here</a>
+                  Are you a Organisation? <a href="../signup_community.html">Click Here</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
The link in modal footer for community guidelines wasn't redirecting anywhere. I fixed this to route to the specific community guidelines page.

